### PR TITLE
Fixes to mutations, also some others

### DIFF
--- a/lib/schemas/agent.gql
+++ b/lib/schemas/agent.gql
@@ -85,10 +85,6 @@ interface Agent {
   relationshipsAsObject(roleId: ID): [AgentRelationship!] # :TODO: category filtering
 
   roles: [AgentRelationshipRole!]
-
-  recipes: [ResourceSpecification!] #TODO: is this useful or even realistic?
-
-  # memberRelationships: [AgentRelationship!]
 }
 
 # Variants of agents
@@ -126,10 +122,6 @@ type Person implements Agent {
   relationshipsAsObject(roleId: ID): [AgentRelationship!] # :TODO: category filtering
 
   roles: [AgentRelationshipRole!]
-
-  recipes: [ResourceSpecification!] #TODO: is this useful or even realistic?
-
-  # memberRelationships: [AgentRelationship!]
 }
 
 """
@@ -138,7 +130,7 @@ A formal or informal group, or legal organization.
 type Organization implements Agent {
   id: ID!
 
-  # :TODO: define how people can create further typing of Organization, also might need a different name
+  # :TODO: define how people can create further typing of Organization
   # type: OrganizationClassification
 
   "The name that this agent will be referred to by."
@@ -168,10 +160,6 @@ type Organization implements Agent {
   relationshipsAsObject(roleId: ID): [AgentRelationship!] # :TODO: category filtering
 
   roles: [AgentRelationshipRole!]
-
-  recipes: [ResourceSpecification!] #TODO: is this useful or even realistic?
-
-  # memberRelationships: [AgentRelationship!]
 }
 
 # Relationships between agents
@@ -214,10 +202,9 @@ type AgentRelationshipRole {
   note: String
 
   # :TODO: https://github.com/valueflows/valueflows/issues/494
-  # classifiedAs: [URI!]
 }
 
-# :TODO: how do we want to do this concept? (see AgentRelationshipRole.classifiedAs)
+# :TODO: how do we want to do this concept?
 # """
 # Generalized behaviors for agent relationship roles
 # """

--- a/lib/schemas/knowledge.gql
+++ b/lib/schemas/knowledge.gql
@@ -4,8 +4,6 @@
 #
 # Provides functionality for classifying and organising other parts of the system, including recipes.
 #
-# :TODO: need to figure out a way of making these enums extensible while
-#        still validating implementations
 #
 ##
 
@@ -27,24 +25,24 @@ type Action {
 
 # Core VF action IDs & `resourceEffect`s:
 # @see https://github.com/valueflows/valueflows/issues/487
-#   dropoff   (+) transported resource or person leaves the process, the same resource will appear in input with vf:pickup verb
-#   pickup    (-) transported resource or person enters the process, the same resource will appear in output with vf:dropoff verb
-#   consume   (-) for example an ingredient composed into the output, after the process the ingredient is gone
-#   use       (0) for example a tool used in process, after the process, the tool still exists
-#   work      (0) labor power towards a process
-#   cite      (0) for example a design file, neither used nor consumed, the file remains available at all times
-#   produce   (+) new resource created in that process or an existing stock resource added to
-#   accept    (0) in processes like repair or maintentance, the same resource will appear in output with vf:modify verb
-#   modify    (0) in processes like repair or maintentance, the same resource will appear in input with vf:accept verb
-#   pass      (0) possible output of a testing or reviewing process, indicating the resource passed, the same resource will appear in input with *vf:accept* verb
-#   fail      (0) possible output of a testing or reviewing process, indicating the resource failed, the same resource will appear in input with *vf:accept* verb
+#   dropoff             (+) transported resource or person leaves the process, the same resource will appear in input with vf:pickup verb
+#   pickup              (-) transported resource or person enters the process, the same resource will appear in output with vf:dropoff verb
+#   consume             (-) for example an ingredient composed into the output, after the process the ingredient is gone
+#   use                 (0) for example a tool used in process, after the process, the tool still exists
+#   work                (0) labor power towards a process
+#   cite                (0) for example a design file, neither used nor consumed, the file remains available at all times
+#   produce             (+) new resource created in that process or an existing stock resource added to
+#   accept              (0) in processes like repair or maintentance, the same resource will appear in output with vf:modify verb
+#   modify              (0) in processes like repair or maintentance, the same resource will appear in input with vf:accept verb
+#   pass                (0) possible output of a testing or reviewing process, indicating the resource passed, the same resource will appear in input with *vf:accept* verb
+#   fail                (0) possible output of a testing or reviewing process, indicating the resource failed, the same resource will appear in input with *vf:accept* verb
 #   deliver-service     (0) new service produced and delivered (being a service implies that an agent actively receives the service)
 #   transfer-all-rights (-+) give full (in the human realm) rights and responsibilities to another agent, without transferring physical custody
 #   transfer-custody    (-+) give physical custody and control of a resource, without full accounting or ownership rights
 #   transfer-complete   (-+) give full rights and responsibilities plus physical custody
-#   move      (-+) change location and/or identity of a resource with no change of agent
-#   raise     (+) adjusts a quantity up based on a beginning balance or inventory count
-#   lower     (-) adjusts a quantity down based on a beginning balance or inventory count
+#   move                (-+) change location and/or identity of a resource with no change of agent
+#   raise               (+) adjusts a quantity up based on a beginning balance or inventory count
+#   lower               (-) adjusts a quantity down based on a beginning balance or inventory count
 
 """
 Specification of a kind of resource. Could define a material item, service, digital item, currency account, etc.

--- a/lib/schemas/mutation.gql
+++ b/lib/schemas/mutation.gql
@@ -50,26 +50,21 @@
 # interface AgentParams {
 #   name: String
 #   image: URI
-#   email: String
 #   primaryLocation: String
 #   note: String
 # }
 
 input AgentCreateParams { # implements AgentParams
-  primaryPhone: String
   name: String!
   image: URI
-  email: String
   primaryLocation: ID
   note: String
 }
 
 input AgentUpdateParams { # implements UpdateParams & AgentParams
   id: ID!
-  primaryPhone: String
   name: String
   image: URI
-  email: String
   primaryLocation: ID
   note: String
 }
@@ -126,18 +121,26 @@ type AgentRelationshipResponse {
 #   receiver: ID
 #   resourceQuantity: IQuantityValue
 #   effortQuantity: IQuantityValue
-#   :TODO: time
+#   hasBeginning: DateTime
+#   hasEnd: DateTime
+#   hasPointInTime: DateTime
+#   before: DateTime
+#   after: DateTime
 #   note: String
 #   inScopeOf: [AnyType!]
 #   atLocation: ID
+#   agreedIn: URI
+#   realizationOf: ID # Agreement
+#   triggeredBy: ID # EconomicEvent
+#   toResourceInventoriedAs: ID # EconomicResource
 # }
 
 input EconomicEventCreateParams { # implements EconomicEventParams
   action: ID! # Action
   inputOf: ID # Process
   outputOf: ID # Process
-  provider: ID # Agent
-  receiver: ID # Agent
+  provider: ID! # Agent
+  receiver: ID! # Agent
   inScopeOf: [AnyType!]
   resourceInventoriedAs: ID # EconomicResource
   resourceClassifiedAs: [URI!]
@@ -151,6 +154,10 @@ input EconomicEventCreateParams { # implements EconomicEventParams
   before: DateTime
   after: DateTime
   note: String
+  agreedIn: URI
+  realizationOf: ID # Agreement
+  triggeredBy: ID # EconomicEvent
+  toResourceInventoriedAs: ID # EconomicResource
 }
 
 input EconomicEventUpdateParams { # implements UpdateParams & EconomicEventParams
@@ -173,6 +180,10 @@ input EconomicEventUpdateParams { # implements UpdateParams & EconomicEventParam
   before: DateTime
   after: DateTime
   note: String
+  agreedIn: URI
+  realizationOf: ID # Agreement
+  triggeredBy: ID # EconomicEvent
+  toResourceInventoriedAs: ID # EconomicResource
 }
 
 type EconomicEventResponse {
@@ -182,21 +193,26 @@ type EconomicEventResponse {
 
 
 # interface EconomicResourceParams {
+#   name: String
 #   classifiedAs: [URI!]
-#   resourceConformsTo: ID # ResourceSpecification
+#   conformsTo: ID # ResourceSpecification
 #   trackingIdentifier: String
+#   lot: ID # ProductBatch
 #   image: URI # URI
 #   accountingQuantity: IQuantityValue
 #   onhandQuantity: IQuantityValue
 #   currentLocation: ID
 #   note: String
-#   inScopeOf: [AnyType!]
+#   containedIn: ID # EconomicResource
+#   unitOfEffort: ID # Unit
 # }
 
 """
 Input `EconomicResource` type used when sending events to setup initial resource recordings
 """
 input EconomicResourceCreateParams { # implements EconomicResourceParams
+  name: String
+  classifiedAs: [URI!]
   conformsTo: ID! # ResourceSpecification
   unitOfEffort: ID # Unit
   trackingIdentifier: String
@@ -207,11 +223,10 @@ input EconomicResourceCreateParams { # implements EconomicResourceParams
   containedIn: ID # EconomicResource
   currentLocation: ID # SpatialThing
   note: String
-  # inScopeOf: [AnyType!] :TODO: are resources supposed to have this separately to events?
 }
 
 input EconomicResourceUpdateParams { # implements UpdateParams & EconomicResourceParams
-  id: ID!,
+  id: ID!
   classifiedAs: [URI!]
   conformsTo: ID # ResourceSpecification
   unitOfEffort: ID # Unit
@@ -223,7 +238,6 @@ input EconomicResourceUpdateParams { # implements UpdateParams & EconomicResourc
   containedIn: ID # EconomicResource
   currentLocation: ID # SpatialThing
   note: String
-  # inScopeOf: [AnyType!] :TODO: are resources supposed to have this separately to events?
 }
 
 type EconomicResourceResponse {
@@ -237,7 +251,6 @@ type EconomicResourceResponse {
 #   resourceQuantity: IQuantityValue
 #   effortQuantity: IQuantityValue
 #   note: String
-#   inScopeOf: [AnyType!]
 # }
 
 input FulfillmentCreateParams { # implements FulfillmentParams
@@ -264,15 +277,23 @@ type FulfillmentResponse {
 
 # interface ProcessParams {
 #   name: String
-#   :TODO: time
-#   hasDuration: IDuration
+#   hasBeginning: DateTime
+#   hasEnd: DateTime
+#   before: DateTime
+#   after: DateTime
 #   note: String
 #   inScopeOf: String
+#   plannedWithin: ID # Plan
+#   finished: Boolean
 # }
 
 input ProcessCreateParams { # implements ProcessParams
   name: String!
-  hasDuration: IDuration
+  hasBeginning: DateTime
+  hasEnd: DateTime
+  before: DateTime
+  after: DateTime
+  finished: Boolean
   note: String
   inScopeOf: [AnyType!]
   plannedWithin: ID # Plan
@@ -281,7 +302,10 @@ input ProcessCreateParams { # implements ProcessParams
 input ProcessUpdateParams { # implements UpdateParams & ProcessParams
   id: ID!
   name: String
-  hasDuration: IDuration
+  hasBeginning: DateTime
+  hasEnd: DateTime
+  before: DateTime
+  after: DateTime
   finished: Boolean
   note: String
   inScopeOf: [AnyType!]
@@ -300,15 +324,15 @@ type ProcessResponse {
 # }
 
 input AppreciationCreateParams {
-  appreciationOf: ID
-  appreciationWith: ID
+  appreciationOf: ID # EconomicEvent
+  appreciationWith: ID # EconomicEvent
   note: String
 }
 
 input AppreciationUpdateParams {
   id: ID!
-  appreciationOf: ID
-  appreciationWith: ID
+  appreciationOf: ID # EconomicEvent
+  appreciationWith: ID # EconomicEvent
   note: String
 }
 
@@ -325,6 +349,7 @@ type AppreciationResponse {
 ################################################################################
 
 # interface IntentParams {
+#   name: String
 #   action: ID
 #   inputOf: ID
 #   outputOf: ID
@@ -332,6 +357,7 @@ type AppreciationResponse {
 #   receiver: ID
 #   resourceConformsTo: ID
 #   resourceClassifiedAs: [URI!]
+#   resourceInventoriedAs: ID
 #   resourceQuantity: IQuantityValue
 #   effortQuantity: IQuantityValue
 #   availableQuantity: IQuantityValue
@@ -344,19 +370,22 @@ type AppreciationResponse {
 #   note: String
 #   inScopeOf: [AnyType!]
 #   atLocation: ID
-#   agreedIn: String
+#   agreedIn: URI
+#   finished: Boolean
 # }
 
 input IntentCreateParams { # implements IntentParams
   action: ID!
+  name: String
   inputOf: ID
   outputOf: ID
   provider: ID
   receiver: ID
   resourceConformsTo: ID
   resourceClassifiedAs: [URI!]
-  flowQuantity: IQuantityValue
-  unitQuantity: IQuantityValue
+  resourceInventoriedAs: ID
+  resourceQuantity: IQuantityValue
+  effortQuantity: IQuantityValue
   availableQuantity: IQuantityValue
   hasBeginning: DateTime
   hasEnd: DateTime
@@ -367,15 +396,13 @@ input IntentCreateParams { # implements IntentParams
   note: String
   inScopeOf: [AnyType!]
   atLocation: ID # SpatialThing
-
-  # pending review- see https://github.com/valueflows/vf-graphql/issues/26
-  # LF 2019-9-15 didn't totally fix this, unclear what needs to happen
-  agreedIn: ID # Agreement
-  underExternalAgreement: URI
+  agreedIn: URI
+  finished: Boolean
 }
 
 input IntentUpdateParams { # implements UpdateParams & IntentParams
   id: ID!
+  name: String
   action: ID
   inputOf: ID
   outputOf: ID
@@ -383,6 +410,7 @@ input IntentUpdateParams { # implements UpdateParams & IntentParams
   receiver: ID
   resourceConformsTo: ID
   resourceClassifiedAs: [URI!]
+  resourceInventoriedAs: ID
   resourceQuantity: IQuantityValue
   effortQuantity: IQuantityValue
   availableQuantity: IQuantityValue
@@ -396,8 +424,7 @@ input IntentUpdateParams { # implements UpdateParams & IntentParams
   note: String
   inScopeOf: [AnyType!]
   atLocation: ID # SpatialThing
-  agreedIn: ID # Agreement
-  underExternalAgreement: URI
+  agreedIn: URI
 }
 
 type IntentResponse {
@@ -421,10 +448,12 @@ type IntentResponse {
 #   hasPointInTime: DateTime
 #   before: DateTime
 #   after: DateTime
+#   finished: Boolean
 #   note: String
 #   inScopeOf: [AnyType!]
+#   independentDemandOf: ID #Plan
 #   atLocation: ID
-#   agreedIn: String
+#   agreedIn: URI
 #   clauseOf: Agreement
 # }
 
@@ -432,8 +461,8 @@ input CommitmentCreateParams { # implements CommitmentParams
   action: ID!
   inputOf: ID
   outputOf: ID
-  provider: ID
-  receiver: ID
+  provider: ID!
+  receiver: ID!
   resourceClassifiedAs: [URI!]
   resourceConformsTo: ID
   resourceInventoriedAs: ID
@@ -444,12 +473,12 @@ input CommitmentCreateParams { # implements CommitmentParams
   hasPointInTime: DateTime
   before: DateTime
   after: DateTime
+  finished: Boolean
   note: String
   inScopeOf: [AnyType!]
   independentDemandOf: ID #Plan
   atLocation: ID # SpatialThing
-  agreedIn: ID # Agreement
-  underExternalAgreement: URI
+  agreedIn: URI
   clauseOf: ID # Agreement
 }
 
@@ -474,8 +503,7 @@ input CommitmentUpdateParams { # implements UpdateParams & CommitmentParams
   inScopeOf: [AnyType!]
   independentDemandOf: ID #Plan
   atLocation: ID # SpatialThing
-  agreedIn: ID # Agreement
-  underExternalAgreement: URI
+  agreedIn: URI
   clauseOf: ID # Agreement
 }
 
@@ -514,26 +542,10 @@ type SatisfactionResponse {
 }
 
 
-# interface PlanParams {
-
-# }
-
-# type PlanCreateParams { # implements PlanParams
-
-# }
-
-# type PlanUpdateParams { # implements UpdateParams & PlanParams
-
-# }
-
-# type PlanResponse {
-#   plan: Plan
-# }
-
-
 # interface AgreementParams {
 #   name: String
-#   agreedTime: DateTime
+#   created: DateTime
+#   note: String
 # }
 
 input AgreementCreateParams { # implements AgreementParams
@@ -555,10 +567,9 @@ type AgreementResponse {
 
 
 # type ClaimParams {
-#   id: ID!
 #   action: Action
-#   provider: Agent!
-#   receiver: Agent!
+#   provider: Agent
+#   receiver: Agent
 #   resourceClassifiedAs: [URI!]
 #   resourceConformsTo: ResourceSpecification
 #   resourceQuantity: IQuantityValue
@@ -567,21 +578,24 @@ type AgreementResponse {
 #   created: DateTime
 #   finished: Boolean
 #   note: String
-#   agreedIn: String
+#   agreedIn: URI
+#   inScopeOf: [AnyType!]
 # }
 
 input ClaimCreateParams {
-  action: ID # Action
-  provider: ID # Agent
-  receiver: ID # Agent
+  action: ID! # Action
+  provider: ID! # Agent
+  receiver: ID! # Agent
   resourceClassifiedAs: [URI!]
   resourceConformsTo: ID # ResourceSpecification
   resourceQuantity: IQuantityValue
   effortQuantity: IQuantityValue
-  triggeredBy: ID #EconomicEvent
+  triggeredBy: ID # EconomicEvent
+  created: DateTime
+  finished: Boolean
   note: String
-  agreedIn: ID
-  underExternalAgreement: URI
+  agreedIn: URI
+  inScopeOf: [AnyType!]
 }
 
 input ClaimUpdateParams {
@@ -594,10 +608,11 @@ input ClaimUpdateParams {
   resourceQuantity: IQuantityValue
   effortQuantity: IQuantityValue
   triggeredBy: ID
+  created: DateTime
   finished: Boolean
   note: String
-  agreedIn: ID
-  underExternalAgreement: URI
+  agreedIn: URI
+  inScopeOf: [AnyType!]
 }
 
 type ClaimResponse {
@@ -606,7 +621,6 @@ type ClaimResponse {
 
 
 # type SettlementParams {
-#   id: ID!
 #   settles: ID! # Claim
 #   settledBy: ID! # EconomicEvent
 #   resourceQuantity: IQuantityValue
@@ -636,16 +650,21 @@ type SettlementResponse {
 }
 
 
+# interface PlanParams {
+#   name: String
+#   created: DateTime
+#   before: DateTime
+#   note: String
+# }
 
-input PlanCreateParams {
-  id: ID!
+input PlanCreateParams { # implements PlanParams
   name: String!
   created: DateTime
   before: DateTime
   note: String
 }
 
-input PlanUpdateParams {
+input PlanUpdateParams { # implements UpdateParams & PlanParams
   id: ID!
   name: String
   created: DateTime
@@ -658,6 +677,38 @@ type PlanResponse {
 }
 
 
+# interface ScenarioParams {
+#   name: String
+#   definedAs: ScenarioDefinition
+#   hasBeginning: DateTime
+#   hasEnd: DateTime
+#   inScopeOf: [AnyType!]
+#   note: String
+# }
+
+input ScenarioCreateParams { # implements ScenarioParams
+  name: String!
+  definedAs: ScenarioDefinition
+  hasBeginning: DateTime
+  hasEnd: DateTime
+  inScopeOf: [AnyType!]
+  note: String
+}
+
+input ScenarioUpdateParams { # implements UpdateParams & ScenarioParams
+  id: ID!
+  name: String
+  definedAs: ScenarioDefinition
+  hasBeginning: DateTime
+  hasEnd: DateTime
+  inScopeOf: [AnyType!]
+  note: String
+}
+
+type ScenarioResponse {
+  scenario: Scenario
+}
+
 
 
 
@@ -669,14 +720,12 @@ type PlanResponse {
 # interface ResourceSpecificationParams {
 #   name: String
 #   image: URI
-#   resourceClassifiedAs: [URI!]
 #   note: String
 # }
 
 input ResourceSpecificationCreateParams { # implements ResourceSpecificationParams
   name: String!
   image: URI
-  resourceClassifiedAs: [URI!]
   note: String
 }
 
@@ -684,7 +733,6 @@ input ResourceSpecificationUpdateParams { # implements UpdateParams & ResourceSp
   id: ID!
   name: String
   image: URI
-  resourceClassifiedAs: [URI!]
   note: String
 }
 
@@ -731,7 +779,6 @@ type RecipeResourceResponse {
 # interface RecipeProcessParams {
 #   name: String
 #   hasDuration: IDuration
-#   durationMultiplier: Float
 #   processClassifiedAs: [URI!]
 #   note: String
 # }
@@ -739,7 +786,6 @@ type RecipeResourceResponse {
 input RecipeProcessCreateParams { # implements RecipeProcessParams
   name: String!
   hasDuration: IDuration
-  durationMultiplier: Float
   processClassifiedAs: [URI!]
   note: String
 }
@@ -748,7 +794,6 @@ input RecipeProcessUpdateParams { # implements UpdateParams & RecipeProcessParam
   id: ID!
   name: String
   hasDuration: IDuration
-  durationMultiplier: Float
   processClassifiedAs: [URI!]
   note: String
 }
@@ -781,7 +826,6 @@ type ProcessSpecificationResponse {
 
 # interface RecipeFlowParams {
 #   action: Action
-#   resourceClassifiedAs: [URI!]
 #   recipeFlowResource: RecipeResource
 #   resourceQuantity: IQuantityValue
 #   effortQuantity: IQuantityValue
@@ -794,7 +838,6 @@ type ProcessSpecificationResponse {
 
 input RecipeFlowCreateParams { # implements RecipeFlowParams
   action: ID! # Action
-  resourceClassifiedAs: [URI!]
   recipeFlowResource: ID # RecipeResource!
   resourceQuantity: IQuantityValue
   effortQuantity: IQuantityValue
@@ -808,7 +851,6 @@ input RecipeFlowCreateParams { # implements RecipeFlowParams
 input RecipeFlowUpdateParams { # implements UpdateParams & RecipeFlowParams
   id: ID!
   action: ID # Action
-  resourceClassifiedAs: [URI!]
   recipeFlowResource: ID # RecipeResource
   resourceQuantity: IQuantityValue
   effortQuantity: IQuantityValue
@@ -827,17 +869,20 @@ type RecipeFlowResponse {
 # interface AgentRelationshipRoleParams {
 #   label: String
 #   inverseLabel: String
+#   note: String
 # }
 
 input AgentRelationshipRoleCreateParams { # implements AgentRelationshipRoleParams
   label: String!
   inverseLabel: String
+  note: String
 }
 
 input AgentRelationshipRoleUpdateParams { # implements UpdateParams & AgentRelationshipRoleParams
   id: ID!
   label: String
   inverseLabel: String
+  note: String
 }
 
 type AgentRelationshipRoleResponse {
@@ -845,6 +890,29 @@ type AgentRelationshipRoleResponse {
 }
 
 
+
+# interface ScenarioDefinitionParams {
+#   name: String
+#   hasDuration: IDuration
+#   note: String
+# }
+
+input ScenarioDefinitionCreateParams { # implements ScenarioDefinitionParams
+  name: String
+  hasDuration: IDuration
+  note: String
+}
+
+input ScenarioDefinitionUpdateParams { # implements UpdateParams & ScenarioDefinitionParams
+  id: ID!
+  label: String
+  inverseLabel: String
+  note: String
+}
+
+type ScenarioDefinitionResponse {
+  scenarioDefinition: ScenarioDefinition
+}
 
 
 
@@ -919,6 +987,10 @@ type Mutation {
   # createPlanFromRecipe(): PlanResponse
   updatePlan(plan: PlanUpdateParams!): PlanResponse
   deletePlan(id: String!): Boolean
+
+  createScenario(plan: ScenarioCreateParams!): ScenarioResponse
+  updateScenario(plan: ScenarioUpdateParams!): ScenarioResponse
+  deleteScenario(id: String!): Boolean
 
   createAgreement(agreement: AgreementCreateParams): AgreementResponse
   updateAgreement(agreement: AgreementUpdateParams): AgreementResponse

--- a/lib/schemas/observation.gql
+++ b/lib/schemas/observation.gql
@@ -25,10 +25,10 @@ type EconomicEvent {
   outputOf: Process
 
   "The economic agent from whom the actual economic event is initiated."
-  provider: Agent
+  provider: Agent!
 
   "The economic agent whom the actual economic event is for."
-  receiver: Agent
+  receiver: Agent!
 
   "Economic resource involved in the economic event."
   resourceInventoriedAs: EconomicResource
@@ -73,15 +73,13 @@ type EconomicEvent {
   inScopeOf: [AnyType!]
 
   "Reference to an agreement between agents which specifies the rules or policies or calculations which govern this economic event."
-  agreedIn: AnyAgreement
+  agreedIn: URI
 
   "This economic event occurs as part of this agreement."
   realizationOf: Agreement
 
   "References another economic event that implied this economic event, often based on a prior agreement."
   triggeredBy: EconomicEvent
-
-  # requestDistribution: Boolean
 
   ##############################################################################
   # inverse relationships and queries
@@ -98,9 +96,6 @@ type EconomicEvent {
   track: [ProductionFlowItem!]
   trace: [ProductionFlowItem!]
 
-  # validations: [Validation!]
-  # isValidated: Boolean
-
   "The economic event can be safely deleted, has no dependent information."
   deletable: Boolean
 }
@@ -110,6 +105,9 @@ A resource which is useful to people or the ecosystem.
 """
 type EconomicResource {
   id: ID!
+
+  "An informal or formal textual identifier for an item. Does not imply uniqueness."
+  name: String
 
   "References one or more concepts in a common taxonomy or other classification scheme for purposes of categorization or grouping."
   classifiedAs: [URI!]
@@ -158,9 +156,6 @@ type EconomicResource {
 
   trace: [EconomicEvent!]
   track: [EconomicEvent!]
-
-  # resourceContacts: [Agent!]
-  # owners: [Agent!]  TODO: define agent-resource relationships, if we do need them
 }
 
 """

--- a/lib/schemas/planning.gql
+++ b/lib/schemas/planning.gql
@@ -382,12 +382,6 @@ type ReferencedAgreement {
   id: URI!
 }
 
-"""
-References either an agreement formally managed by `Commitment`s & `EconomicEvent`s,
-or an external agreement which is loosely held to govern resource flows.
-"""
-union AnyAgreement = Agreement | ReferencedAgreement
-
 
 """
 Published requests or offers, sometimes with what is expected in return.

--- a/lib/schemas/planning.gql
+++ b/lib/schemas/planning.gql
@@ -26,10 +26,10 @@ type Commitment {
   outputOf: Process
 
   "The economic agent from whom the commitment is initiated."
-  provider: Agent
+  provider: Agent!
 
   "The economic agent whom the commitment is for."
-  receiver: Agent
+  receiver: Agent!
 
   "References a concept in a common taxonomy or other classification scheme for purposes of categorization or grouping."
   resourceClassifiedAs: [URI!]
@@ -37,7 +37,7 @@ type Commitment {
   "The primary resource specification or definition of an existing or potential economic resource. A resource will have only one, as this specifies exactly what the resource is."
   resourceConformsTo: ResourceSpecification
 
-  "Economic resource involved in the commitment."
+  "Exact economic resource involved in the commitment."
   resourceInventoriedAs: EconomicResource
 
   "References the ProcessSpecification of the last process the desired economic resource went through. Stage is used when the last process is important for finding proper resources, such as where the publishing process wants only documents that have gone through the editing process."
@@ -83,9 +83,9 @@ type Commitment {
   inScopeOf: [AnyType!]
 
   "Reference to an agreement between agents which specifies the rules or policies or calculations which govern this commitment."
-  agreedIn: AnyAgreement
+  agreedIn: URI
 
-  "This commitment is part of the agreement."
+  "This commitment is part of the exchange agreement."
   clauseOf: Agreement
 
   "Represents a desired deliverable expected from this plan."
@@ -96,7 +96,6 @@ type Commitment {
 
   "The economic event which completely or partially fulfills a commitment."
   fulfilledBy: [Fulfillment!]
-  # fulfilledBy(requestDistribution: Boolean): [Fulfillment!]
 
   "An intent satisfied fully or partially by an economic event or commitment."
   satisfies: [Satisfaction!]
@@ -110,7 +109,7 @@ type Commitment {
 }
 
 """
-A planned economic flow, which can lead to economic events (sometimes through commitments).
+A planned economic flow which has not been committed to, which can lead to economic events (sometimes through commitments).
 """
 type Intent {
   id: ID!
@@ -121,16 +120,16 @@ type Intent {
   "Relates an intent to a verb, such as consume, produce, work, improve, etc."
   action: Action!
 
-  "A `Process` to which this `Intent` is hoping to contribute towards."
+  "Defines the process to which this intent is an input."
   inputOf: Process
 
-  "A `Process` which this `Intent` will eventuate as a result of."
+  "Defines the process to which this intent is an output."
   outputOf: Process
 
   "The economic agent from whom the intent is initiated. This implies that the intent is an offer."
   provider: Agent
 
-  "The economic agent whom the intent is for.  This implies that the intent is a request"
+  "The economic agent whom the intent is for.  This implies that the intent is a request."
   receiver: Agent
 
   "References a concept in a common taxonomy or other classification scheme for purposes of categorization or grouping."
@@ -182,7 +181,7 @@ type Intent {
   inScopeOf: [AnyType!]
 
   "Reference to an agreement between agents which specifies the rules or policies or calculations which govern this intent."
-  agreedIn: AnyAgreement
+  agreedIn: URI
 
   ##############################################################################
   # inverse relationships and queries
@@ -237,7 +236,7 @@ type Claim {
   note: String
 
   "Reference to an agreement between agents which specifies the rules or policies or calculations which govern this claim."
-  agreedIn: AnyAgreement
+  agreedIn: URI
 
   "Grouping around something to create a boundary or context, used for documenting, accounting, planning."
   inScopeOf: [AnyType!]
@@ -321,7 +320,6 @@ input planProcessSearchParams {
 
 """
 A logical collection of processes that constitute a body of planned work with defined deliverable(s).
-NOTE: Not accepted in VF.  Other option is to be a high level process.
 """
 type Plan {
   id: ID!
@@ -350,13 +348,7 @@ type Plan {
   processes(filter: planProcessSearchParams): [Process!]
   independentDemands: [Commitment!]
 
-  # leaving the following until something is needed
-  # plannedNonWorkInputs: [Commitment!]
-  # plannedOutputs: [Commitment!]
-  # nonWorkInputs: [EconomicEvent!]
-  # outputs: [EconomicEvent!]
-  # kanbanState: String #TODO: codify this?
-  # deletable: Boolean
+  deletable: Boolean
 }
 
 """

--- a/lib/schemas/query.gql
+++ b/lib/schemas/query.gql
@@ -41,9 +41,6 @@ type Query {
   economicResource(id: ID): EconomicResource
   allEconomicResources: [EconomicResource!]
 
-  #validation(id: ID): Validation
-  #allValidations: [Validation!]
-
   process(id: ID): Process
   allProcesses: [Process!]
 
@@ -66,17 +63,6 @@ type Query {
   allAgreements: [Agreement!]
 
   # Knowledge layer
-  # resourceClassification(id: ID): ResourceClassification
-  # allResourceClassifications: [ResourceClassification!]
-  # # resourceClassificationsByProcessCategory(category: EconomicResourceProcessCategory): [ResourceClassification!]
-  # resourceClassificationsByAction(action: Action): [ResourceClassification!]
-  # resourceClassificationsByFacetValues(facetValues: String): [ResourceClassification!]
-
-  # agentResourceClassification(id: ID): AgentResourceClassification
-  # allAgentResourceClassifications: [AgentResourceClassification!]
-
-  # processClassification(id: ID): ProcessClassification
-  # allProcessClassifications: [ProcessClassification!]
 
   # organizationClassification(id: ID): OrganizationClassification
   # allOrganizationClassifications: [OrganizationClassification!]
@@ -98,9 +84,6 @@ type Query {
 
   action(id: ID): Action
   allActions: [Action!]
-
-  #facet(id: ID): Facet
-  #allFacets: [Facet!]
 
   # System config layer
   unit(id: ID): Unit


### PR DESCRIPTION
@pospi I went through all the graphql stuff, made some adjustments to the layer docs.  And a lot of fixes to the mutations.  I am missing some technical knowledge, so please review carefully!  Although at least I think it is better than it was.... :)

Questions (that might imply some re-work):
1. I noticed sometimes the commented section in each mutation was `interface` and sometimes `type`.  Didn't know what to do with that, above my pay grade.
2. There were missing things from the `interface` section that sometimes made sense to me and sometimes didn't.  Didn't know if it was OK to have missing things, seemed like from the comments that the create and update params needed to implement something?  If not, maybe we should take out `finished` for example on creates.  Or on the other hand, why not leave it, and allow the option of creating data after the fact?  The resolvers could default to false as needed.
3. `created` I decided shouldn't be just the machine time, but should be able to be input since it has some additional semantic meaning where it is included.  You might disagree, let me know.  (I don't think of it exactly as the timestamp we talked about adding to all records.)
