### PR TITLE
VF v.4

### DIFF
--- a/lib/schemas/agent.gql
+++ b/lib/schemas/agent.gql
@@ -86,7 +86,7 @@ interface Agent {
 
   roles: [AgentRelationshipRole!]
 
-  recipes: [ResourceSpecification!] #TODO: is this useful or even realistic?
+  # recipes: [ResourceSpecification!] #TODO: is this useful or even realistic? not yet
 
   # memberRelationships: [AgentRelationship!]
 }
@@ -127,7 +127,7 @@ type Person implements Agent {
 
   roles: [AgentRelationshipRole!]
 
-  recipes: [ResourceSpecification!] #TODO: is this useful or even realistic?
+  # recipes: [ResourceSpecification!] #TODO: is this useful or even realistic? not yet
 
   # memberRelationships: [AgentRelationship!]
 }
@@ -169,7 +169,7 @@ type Organization implements Agent {
 
   roles: [AgentRelationshipRole!]
 
-  recipes: [ResourceSpecification!] #TODO: is this useful or even realistic?
+  # recipes: [ResourceSpecification!] #TODO: is this useful or even realistic? not yet
 
   # memberRelationships: [AgentRelationship!]
 }
@@ -205,10 +205,10 @@ type AgentRelationshipRole {
   id: ID!
 
   "The human readable name of the role, from the subject to the object."
-  label: String!
+  roleLabel: String!
 
   "The human readable name of the role, from the object to the subject."
-  inverseLabel: String
+  inverseRoleLabel: String
 
   "A textual description or comment."
   note: String

--- a/lib/schemas/knowledge.gql
+++ b/lib/schemas/knowledge.gql
@@ -22,7 +22,13 @@ type Action {
   label: String!
 
   "The effect of an economic event on a resource, increment, decrement, no effect, or decrement resource and increment 'to' resource."
-  resourceEffect: String! # "+", "-", "0", "-+"
+  resourceEffect: String! # "increment", "decrement", "noEffect", "decrementIncrement"
+
+  "Denotes if a process input or output, or not related to a process."
+  inputOutput: String # "input", "output", "notApplicable"
+
+  "The action that should be included on the other direction of the process, for example accept with modify."
+  pairsWith: String # "notApplicable", (any of the action labels) TODO: do we want to do this as an actual Action (optional)? In the VF spec they are NamedIndividuals defined in the spec, including "notApplicable".
 }
 
 # Core VF action IDs & `resourceEffect`s:

--- a/lib/schemas/knowledge.gql
+++ b/lib/schemas/knowledge.gql
@@ -114,10 +114,10 @@ type RecipeFlow {
   id: ID!
 
   "The amount and unit of the economic resource counted or inventoried."
-  resourceQuantity: QuantityValue
+  resourceQuantity: Measure
 
   "The amount and unit of the work or use or citation effort-based action. This is often a time duration, but also could be cycle counts or other measures of effort or usefulness."
-  effortQuantity: QuantityValue
+  effortQuantity: Measure
 
   "The resource definition referenced by this flow in the recipe."
   recipeFlowResource: RecipeResource

--- a/lib/schemas/mutation.gql
+++ b/lib/schemas/mutation.gql
@@ -119,13 +119,11 @@ type AgentRelationshipResponse {
 #   outputOf: ID
 #   provider: ID
 #   receiver: ID
-#   resourceQuantity: IQuantityValue
-#   effortQuantity: IQuantityValue
+#   resourceQuantity: IMeasure
+#   effortQuantity: IMeasure
 #   hasBeginning: DateTime
 #   hasEnd: DateTime
 #   hasPointInTime: DateTime
-#   before: DateTime
-#   after: DateTime
 #   note: String
 #   inScopeOf: [AnyType!]
 #   atLocation: ID
@@ -145,14 +143,12 @@ input EconomicEventCreateParams { # implements EconomicEventParams
   resourceInventoriedAs: ID # EconomicResource
   resourceClassifiedAs: [URI!]
   resourceConformsTo: ID # ResourceSpecification
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   atLocation: ID # SpatialThing
   hasBeginning: DateTime
   hasEnd: DateTime
   hasPointInTime: DateTime
-  before: DateTime
-  after: DateTime
   note: String
   agreedIn: URI
   realizationOf: ID # Agreement
@@ -171,14 +167,12 @@ input EconomicEventUpdateParams { # implements UpdateParams & EconomicEventParam
   resourceInventoriedAs: ID
   resourceClassifiedAs: [URI!]
   resourceConformsTo: ID
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   atLocation: ID # SpatialThing
   hasBeginning: DateTime
   hasEnd: DateTime
   hasPointInTime: DateTime
-  before: DateTime
-  after: DateTime
   note: String
   agreedIn: URI
   realizationOf: ID # Agreement
@@ -199,12 +193,14 @@ type EconomicEventResponse {
 #   trackingIdentifier: String
 #   lot: ID # ProductBatch
 #   image: URI # URI
-#   accountingQuantity: IQuantityValue
-#   onhandQuantity: IQuantityValue
+#   accountingQuantity: IMeasure
+#   onhandQuantity: IMeasure
 #   currentLocation: ID
 #   note: String
 #   containedIn: ID # EconomicResource
 #   unitOfEffort: ID # Unit
+#   state: ID # Action
+#   stage: ID # ProcessSpecification
 # }
 
 """
@@ -218,10 +214,12 @@ input EconomicResourceCreateParams { # implements EconomicResourceParams
   trackingIdentifier: String
   lot: ID # ProductBatch
   image: URI # URI
-  accountingQuantity: IQuantityValue
-  onhandQuantity: IQuantityValue
+  accountingQuantity: IMeasure
+  onhandQuantity: IMeasure
   containedIn: ID # EconomicResource
   currentLocation: ID # SpatialThing
+  state: ID # Action
+  stage: ID # Processspecification
   note: String
 }
 
@@ -233,10 +231,12 @@ input EconomicResourceUpdateParams { # implements UpdateParams & EconomicResourc
   trackingIdentifier: String
   lot: ID # ProductBatch
   image: URI # URI
-  accountingQuantity: IQuantityValue
-  onhandQuantity: IQuantityValue
+  accountingQuantity: IMeasure
+  onhandQuantity: IMeasure
   containedIn: ID # EconomicResource
   currentLocation: ID # SpatialThing
+  state: ID # Action
+  stage: ID # Processspecification
   note: String
 }
 
@@ -248,16 +248,16 @@ type EconomicResourceResponse {
 # interface FulfillmentParams {
 #   fulfilledBy: ID # EconomicEvent
 #   fulfills: ID # Commmitment
-#   resourceQuantity: IQuantityValue
-#   effortQuantity: IQuantityValue
+#   resourceQuantity: IMeasure
+#   effortQuantity: IMeasure
 #   note: String
 # }
 
 input FulfillmentCreateParams { # implements FulfillmentParams
   fulfilledBy: ID!
   fulfills: ID!
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   note: String
 }
 
@@ -265,8 +265,8 @@ input FulfillmentUpdateParams { # implements UpdateParams & FulfillmentParams
   id: ID!
   fulfilledBy: ID
   fulfills: ID
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   note: String
 }
 
@@ -279,8 +279,6 @@ type FulfillmentResponse {
 #   name: String
 #   hasBeginning: DateTime
 #   hasEnd: DateTime
-#   before: DateTime
-#   after: DateTime
 #   note: String
 #   inScopeOf: String
 #   plannedWithin: ID # Plan
@@ -291,8 +289,6 @@ input ProcessCreateParams { # implements ProcessParams
   name: String!
   hasBeginning: DateTime
   hasEnd: DateTime
-  before: DateTime
-  after: DateTime
   finished: Boolean
   note: String
   inScopeOf: [AnyType!]
@@ -304,8 +300,6 @@ input ProcessUpdateParams { # implements UpdateParams & ProcessParams
   name: String
   hasBeginning: DateTime
   hasEnd: DateTime
-  before: DateTime
-  after: DateTime
   finished: Boolean
   note: String
   inScopeOf: [AnyType!]
@@ -358,14 +352,13 @@ type AppreciationResponse {
 #   resourceConformsTo: ID
 #   resourceClassifiedAs: [URI!]
 #   resourceInventoriedAs: ID
-#   resourceQuantity: IQuantityValue
-#   effortQuantity: IQuantityValue
-#   availableQuantity: IQuantityValue
+#   resourceQuantity: IMeasure
+#   effortQuantity: IMeasure
+#   availableQuantity: IMeasure
 #   hasBeginning: DateTime
 #   hasEnd: DateTime
 #   hasPointInTime: DateTime
-#   before: DateTime
-#   after: DateTime
+#   due: DateTime
 #   image: URI
 #   note: String
 #   inScopeOf: [AnyType!]
@@ -384,14 +377,13 @@ input IntentCreateParams { # implements IntentParams
   resourceConformsTo: ID
   resourceClassifiedAs: [URI!]
   resourceInventoriedAs: ID
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
-  availableQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
+  availableQuantity: IMeasure
   hasBeginning: DateTime
   hasEnd: DateTime
   hasPointInTime: DateTime
-  before: DateTime
-  after: DateTime
+  due: DateTime
   image: URI
   note: String
   inScopeOf: [AnyType!]
@@ -411,14 +403,13 @@ input IntentUpdateParams { # implements UpdateParams & IntentParams
   resourceConformsTo: ID
   resourceClassifiedAs: [URI!]
   resourceInventoriedAs: ID
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
-  availableQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
+  availableQuantity: IMeasure
   hasBeginning: DateTime
   hasEnd: DateTime
   hasPointInTime: DateTime
-  before: DateTime
-  after: DateTime
+  due: DateTime
   image: URI
   finished: Boolean
   note: String
@@ -441,13 +432,12 @@ type IntentResponse {
 #   resourceClassifiedAs: [URI!]
 #   resourceConformsTo: ID
 #   resourceInventoriedAs: ID
-#   resourceQuantity: IQuantityValue
-#   effortQuantity: IQuantityValue
+#   resourceQuantity: IMeasure
+#   effortQuantity: IMeasure
 #   hasBeginning: DateTime
 #   hasEnd: DateTime
 #   hasPointInTime: DateTime
-#   before: DateTime
-#   after: DateTime
+#   due: DateTime
 #   finished: Boolean
 #   note: String
 #   inScopeOf: [AnyType!]
@@ -466,13 +456,12 @@ input CommitmentCreateParams { # implements CommitmentParams
   resourceClassifiedAs: [URI!]
   resourceConformsTo: ID
   resourceInventoriedAs: ID
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   hasBeginning: DateTime
   hasEnd: DateTime
   hasPointInTime: DateTime
-  before: DateTime
-  after: DateTime
+  due: DateTime
   finished: Boolean
   note: String
   inScopeOf: [AnyType!]
@@ -491,13 +480,12 @@ input CommitmentUpdateParams { # implements UpdateParams & CommitmentParams
   resourceClassifiedAs: [URI!]
   resourceConformsTo: ID
   resourceInventoriedAs: ID
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   hasBeginning: DateTime
   hasEnd: DateTime
   hasPointInTime: DateTime
-  before: DateTime
-  after: DateTime
+  due: DateTime
   finished: Boolean
   note: String
   inScopeOf: [AnyType!]
@@ -515,16 +503,16 @@ type CommitmentResponse {
 # interface SatisfactionParams {
 #   satisfies: Intent
 #   satisfiedBy: Commitment
-#   resourceQuantity: IQuantityValue
-#   effortQuantity: IQuantityValue
+#   resourceQuantity: IMeasure
+#   effortQuantity: IMeasure
 #   note: String
 # }
 
 input SatisfactionCreateParams { # implements SatisfactionParams
   satisfies: ID! # Intent
   satisfiedBy: ID! # Commitment
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   note: String
 }
 
@@ -532,8 +520,8 @@ input SatisfactionUpdateParams { # implements UpdateParams & SatisfactionParams
   id: ID!
   satisfies: ID # Intent
   satisfiedBy: ID # Commitment
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   note: String
 }
 
@@ -572,8 +560,9 @@ type AgreementResponse {
 #   receiver: Agent
 #   resourceClassifiedAs: [URI!]
 #   resourceConformsTo: ResourceSpecification
-#   resourceQuantity: IQuantityValue
-#   effortQuantity: IQuantityValue
+#   resourceQuantity: IMeasure
+#   effortQuantity: IMeasure
+#   due: DateTime
 #   triggeredBy: EconomicEvent!
 #   created: DateTime
 #   finished: Boolean
@@ -588,8 +577,9 @@ input ClaimCreateParams {
   receiver: ID! # Agent
   resourceClassifiedAs: [URI!]
   resourceConformsTo: ID # ResourceSpecification
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
+  due: DateTime
   triggeredBy: ID # EconomicEvent
   created: DateTime
   finished: Boolean
@@ -605,8 +595,9 @@ input ClaimUpdateParams {
   receiver: ID
   resourceClassifiedAs: [URI!]
   resourceConformsTo: ID
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
+  due: DateTime
   triggeredBy: ID
   created: DateTime
   finished: Boolean
@@ -623,16 +614,16 @@ type ClaimResponse {
 # type SettlementParams {
 #   settles: ID! # Claim
 #   settledBy: ID! # EconomicEvent
-#   resourceQuantity: IQuantityValue
-#   effortQuantity: IQuantityValue
+#   resourceQuantity: IMeasure
+#   effortQuantity: IMeasure
 #   note: String
 # }
 
 input SettlementCreateParams {
   settles: ID! # Claim
   settledBy: ID! # EconomicEvent
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   note: String
 }
 
@@ -640,8 +631,8 @@ input SettlementUpdateParams {
   id: ID!
   settles: ID
   settledBy: ID
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   note: String
 }
 
@@ -653,14 +644,14 @@ type SettlementResponse {
 # interface PlanParams {
 #   name: String
 #   created: DateTime
-#   before: DateTime
+#   due: DateTime
 #   note: String
 # }
 
 input PlanCreateParams { # implements PlanParams
   name: String!
   created: DateTime
-  before: DateTime
+  due: DateTime
   note: String
 }
 
@@ -668,7 +659,7 @@ input PlanUpdateParams { # implements UpdateParams & PlanParams
   id: ID!
   name: String
   created: DateTime
-  before: DateTime
+  due: DateTime
   note: String
 }
 
@@ -827,8 +818,8 @@ type ProcessSpecificationResponse {
 # interface RecipeFlowParams {
 #   action: Action
 #   recipeFlowResource: RecipeResource
-#   resourceQuantity: IQuantityValue
-#   effortQuantity: IQuantityValue
+#   resourceQuantity: IMeasure
+#   effortQuantity: IMeasure
 #   recipeInputOf: RecipeProcess
 #   recipeOutputOf: RecipeProcess
 #   stage: ProcessSpecification
@@ -839,8 +830,8 @@ type ProcessSpecificationResponse {
 input RecipeFlowCreateParams { # implements RecipeFlowParams
   action: ID! # Action
   recipeFlowResource: ID # RecipeResource!
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   recipeInputOf: ID # RecipeProcess
   recipeOutputOf: ID # RecipeProcess
   stage: ID # ProcessSpecification
@@ -852,8 +843,8 @@ input RecipeFlowUpdateParams { # implements UpdateParams & RecipeFlowParams
   id: ID!
   action: ID # Action
   recipeFlowResource: ID # RecipeResource
-  resourceQuantity: IQuantityValue
-  effortQuantity: IQuantityValue
+  resourceQuantity: IMeasure
+  effortQuantity: IMeasure
   recipeInputOf: ID # RecipeProcess
   recipeOutputOf: ID # RecipeProcess
   stage: ID # ProcessSpecification
@@ -867,21 +858,21 @@ type RecipeFlowResponse {
 
 
 # interface AgentRelationshipRoleParams {
-#   label: String
-#   inverseLabel: String
+#   roleLabel: String
+#   inverseRoleLabel: String
 #   note: String
 # }
 
 input AgentRelationshipRoleCreateParams { # implements AgentRelationshipRoleParams
-  label: String!
-  inverseLabel: String
+  roleLabel: String!
+  inverseRoleLabel: String
   note: String
 }
 
 input AgentRelationshipRoleUpdateParams { # implements UpdateParams & AgentRelationshipRoleParams
   id: ID!
-  label: String
-  inverseLabel: String
+  roleLabel: String
+  inverseRoleLabel: String
   note: String
 }
 
@@ -905,8 +896,7 @@ input ScenarioDefinitionCreateParams { # implements ScenarioDefinitionParams
 
 input ScenarioDefinitionUpdateParams { # implements UpdateParams & ScenarioDefinitionParams
   id: ID!
-  label: String
-  inverseLabel: String
+  hasDuration: IDuration
   note: String
 }
 

--- a/lib/schemas/observation.gql
+++ b/lib/schemas/observation.gql
@@ -57,12 +57,6 @@ type EconomicEvent {
   "The date/time at which the economic event occurred. Can be used instead of beginning and end."
   hasPointInTime: DateTime
 
-  "The economic event occurred prior to this date/time."
-  before: DateTime
-
-  "The economic event occurred after this date/time."
-  after: DateTime
-
   "The place where an economic event occurs.  Usually mappable."
   atLocation: SpatialThing
 
@@ -194,12 +188,6 @@ type Process {
 
   "The planned end of the process."
   hasEnd: DateTime
-
-  "The due date/time of the process."
-  before: DateTime
-
-  "The process can start after this date/time."
-  after: DateTime
 
   "The process is complete or not.  This is irrespective of if the original goal has been met, and indicates that no more will be done."
   finished: Boolean

--- a/lib/schemas/observation.gql
+++ b/lib/schemas/observation.gql
@@ -43,10 +43,10 @@ type EconomicEvent {
   resourceConformsTo: ResourceSpecification
 
   "The amount and unit of the economic resource counted or inventoried. This is the quantity that could be used to increment or decrement a resource, depending on the type of resource and resource effect of action."
-  resourceQuantity: QuantityValue
+  resourceQuantity: Measure
 
   "The amount and unit of the work or use or citation effort-based action. This is often a time duration, but also could be cycle counts or other measures of effort or usefulness."
-  effortQuantity: QuantityValue
+  effortQuantity: Measure
 
   "The beginning of the economic event."
   hasBeginning: DateTime
@@ -119,10 +119,10 @@ type EconomicResource {
   image: URI
 
   "The current amount and unit of the economic resource for which the agent has primary rights and responsibilities, sometimes thought of as ownership. This can be either stored or derived from economic events affecting the resource."
-  accountingQuantity: QuantityValue
+  accountingQuantity: Measure
 
   "The current amount and unit of the economic resource which is under direct control of the agent.  It may be more or less than the accounting quantity. This can be either stored or derived from economic events affecting the resource."
-  onhandQuantity: QuantityValue
+  onhandQuantity: Measure
 
   "A textual description or comment."
   note: String

--- a/lib/schemas/planning.gql
+++ b/lib/schemas/planning.gql
@@ -41,10 +41,10 @@ type Commitment {
   resourceInventoriedAs: EconomicResource
 
   "The amount and unit of the economic resource counted or inventoried."
-  resourceQuantity: QuantityValue
+  resourceQuantity: Measure
 
   "The amount and unit of the work or use or citation effort-based action. This is often a time duration, but also could be cycle counts or other measures of effort or usefulness."
-  effortQuantity: QuantityValue
+  effortQuantity: Measure
 
   "The planned beginning of the commitment."
   hasBeginning: DateTime
@@ -55,11 +55,8 @@ type Commitment {
   "The planned date/time for the commitment. Can be used instead of beginning and end."
   hasPointInTime: DateTime
 
-  "The due date/time of the commitment."
-  before: DateTime
-
-  "The commitment can start after this date/time."
-  after: DateTime
+  "The time something is expected to be complete."
+  due: DateTime
 
   "The creation time of the commitment."
   created: DateTime
@@ -136,13 +133,13 @@ type Intent {
   resourceInventoriedAs: EconomicResource
 
   "The amount and unit of the economic resource counted or inventoried. This is the quantity that could be used to increment or decrement a resource, depending on the type of resource and resource effect of action."
-  resourceQuantity: QuantityValue
+  resourceQuantity: Measure
 
   "The amount and unit of the work or use or citation effort-based action. This is often a time duration, but also could be cycle counts or other measures of effort or usefulness."
-  effortQuantity: QuantityValue
+  effortQuantity: Measure
 
   "The total quantity of the offered resource available."
-  availableQuantity: QuantityValue
+  availableQuantity: Measure
 
   "The planned beginning of the intent."
   hasBeginning: DateTime
@@ -153,11 +150,8 @@ type Intent {
   "The planned date/time for the intent. Can be used instead of beginning and end."
   hasPointInTime: DateTime
 
-  "The due date/time of the intent."
-  before: DateTime
-
-  "The intent can start after this date/time."
-  after: DateTime
+  "The time something is expected to be complete."
+  due: DateTime
 
   "The intent is complete or not.  This is irrespective of if the original goal has been met, and indicates that no more will be done."
   finished: Boolean
@@ -209,16 +203,16 @@ type Claim {
   resourceConformsTo: ResourceSpecification
 
   "The amount and unit of the economic resource counted or inventoried."
-  resourceQuantity: QuantityValue
+  resourceQuantity: Measure
 
   "The amount and unit of the work or use or citation effort-based action. This is often a time duration, but also could be cycle counts or other measures of effort or usefulness."
-  effortQuantity: QuantityValue
+  effortQuantity: Measure
 
   "The economic event which already occurred which this claim has been made against."
   triggeredBy: EconomicEvent!
 
-  "Indicates that the claim must be filled before the given date."
-  before: DateTime
+  "The time the claim is expected to be settled."
+  due: DateTime
 
   "The data on which the claim was made."
   created: DateTime
@@ -249,10 +243,10 @@ type Fulfillment {
   fulfills: Commitment!
 
   "The amount and unit of the economic resource counted or inventoried."
-  resourceQuantity: QuantityValue
+  resourceQuantity: Measure
 
   "The amount and unit of the work or use or citation effort-based action. This is often a time duration, but also could be cycle counts or other measures of effort or usefulness."
-  effortQuantity: QuantityValue
+  effortQuantity: Measure
 
   "A textual description or comment."
   note: String
@@ -272,10 +266,10 @@ type Satisfaction {
   satisfiedBy: EventOrCommitment!
 
   "The amount and unit of the economic resource counted or inventoried."
-  resourceQuantity: QuantityValue
+  resourceQuantity: Measure
 
   "The amount and unit of the work or use or citation effort-based action. This is often a time duration, but also could be cycle counts or other measures of effort or usefulness."
-  effortQuantity: QuantityValue
+  effortQuantity: Measure
 
   "A textual description or comment."
   note: String
@@ -294,10 +288,10 @@ type Settlement {
   settledBy: EconomicEvent!
 
   "The amount and unit of the economic resource counted or inventoried."
-  resourceQuantity: QuantityValue
+  resourceQuantity: Measure
 
   "The amount and unit of the work or use or citation effort-based action. This is often a time duration, but also could be cycle counts or other measures of effort or usefulness."
-  effortQuantity: QuantityValue
+  effortQuantity: Measure
 
   "A textual description or comment."
   note: String
@@ -324,8 +318,8 @@ type Plan {
   "The date and time the plan was made."
   created: DateTime
 
-  "The due date and time of the plan."
-  before: DateTime
+  "The time the plan is expected to be complete."
+  due: DateTime
 
   "A textual description or comment."
   note: String

--- a/lib/schemas/query.gql
+++ b/lib/schemas/query.gql
@@ -89,8 +89,6 @@ type Query {
   unit(id: ID): Unit
   allUnits: [Unit!]
 
-  Measure(id: ID): Measure
-
   spatialThing(id: ID): SpatialThing
   allSpatialThings: [SpatialThing!]
 

--- a/lib/schemas/query.gql
+++ b/lib/schemas/query.gql
@@ -89,7 +89,7 @@ type Query {
   unit(id: ID): Unit
   allUnits: [Unit!]
 
-  quantityValue(id: ID): QuantityValue
+  Measure(id: ID): Measure
 
   spatialThing(id: ID): SpatialThing
   allSpatialThings: [SpatialThing!]

--- a/lib/schemas/structs.gql
+++ b/lib/schemas/structs.gql
@@ -62,7 +62,7 @@ Mutation input structure for defining measurements. Should be nulled if not pres
 """
 input IMeasure {
   hasNumericalValue: Float! # we now allow Decimal, Double, Float, or Integer - let's discuss!
-  hasUnit: Unit
+  hasUnit: ID # Unit
 }
 
 """

--- a/lib/schemas/structs.gql
+++ b/lib/schemas/structs.gql
@@ -53,7 +53,7 @@ Semantic meaning for measurements: binds a quantity to its measurement unit.
 See http://www.qudt.org/pages/QUDToverviewPage.html
 """
 type Measure {
-  hasNumericalValue: Decimal! # we now allow Decimal, Double, Float, or Integer - let's discuss!
+  hasNumericalValue: Float! # we now allow Decimal, Double, Float, or Integer - let's discuss!
   hasUnit: Unit
 }
 
@@ -61,7 +61,7 @@ type Measure {
 Mutation input structure for defining measurements. Should be nulled if not present, rather than empty.
 """
 input IMeasure {
-  hasNumericalValue: Decimal! # we now allow Decimal, Double, Float, or Integer - let's discuss!
+  hasNumericalValue: Float! # we now allow Decimal, Double, Float, or Integer - let's discuss!
   hasUnit: Unit
 }
 

--- a/lib/schemas/structs.gql
+++ b/lib/schemas/structs.gql
@@ -53,7 +53,7 @@ Semantic meaning for measurements: binds a quantity to its measurement unit.
 See http://www.qudt.org/pages/QUDToverviewPage.html
 """
 type Measure {
-  hasNumericalValue: Float! # we now allow Decimal, Double, Float, or Integer - let's discuss!
+  hasNumericalValue: Float!
   hasUnit: Unit
 }
 
@@ -61,7 +61,7 @@ type Measure {
 Mutation input structure for defining measurements. Should be nulled if not present, rather than empty.
 """
 input IMeasure {
-  hasNumericalValue: Float! # we now allow Decimal, Double, Float, or Integer - let's discuss!
+  hasNumericalValue: Float!
   hasUnit: Unit
 }
 

--- a/lib/schemas/structs.gql
+++ b/lib/schemas/structs.gql
@@ -69,7 +69,7 @@ input IMeasure {
 Mutation input structure for defining time durations.
 """
 input IDuration {
-  numericDuration: Decimal!
+  numericDuration: Float!
   unitType: TimeUnit!
 }
 

--- a/lib/schemas/structs.gql
+++ b/lib/schemas/structs.gql
@@ -40,11 +40,11 @@ type Duration {
 
 """
 Defines a unit of measurement, along with its display symbol.
-See http://qudt.org/1.1/vocab/unit
+From OM2 vocabulary.
 """
 type Unit {
   id: ID!
-  name: String!
+  label: String!
   symbol: String!
 }
 
@@ -52,24 +52,24 @@ type Unit {
 Semantic meaning for measurements: binds a quantity to its measurement unit.
 See http://www.qudt.org/pages/QUDToverviewPage.html
 """
-type QuantityValue {
-  numericValue: Float!
-  unit: Unit
+type Measure {
+  hasNumericalValue: Decimal! # we now allow Decimal, Double, Float, or Integer - let's discuss!
+  hasUnit: Unit
 }
 
 """
 Mutation input structure for defining measurements. Should be nulled if not present, rather than empty.
 """
-input IQuantityValue {
-  numericValue: Float!
-  unit: ID!
+input IMeasure {
+  hasNumericalValue: Decimal! # we now allow Decimal, Double, Float, or Integer - let's discuss!
+  hasUnit: Unit
 }
 
 """
 Mutation input structure for defining time durations.
 """
 input IDuration {
-  numericDuration: Float!
+  numericDuration: Decimal!
   unitType: TimeUnit!
 }
 


### PR DESCRIPTION
QUDT > OM
Action properties
AgentRelationshipRole property names
Remove time before/after, add vf:due

Point of discussion:
>hasNumericalValue: Decimal! # we now allow Decimal, Double, Float, or Integer - let's discuss!

See https://github.com/valueflows/valueflows/issues/268#issuecomment-541824287 and before/after for some of the discussion in VF.