### PR TITLE
v.4.1: primaryAccountable, transfer-complete > transfer

### DIFF
--- a/lib/schemas/knowledge.gql
+++ b/lib/schemas/knowledge.gql
@@ -45,7 +45,7 @@ type Action {
 #   deliver-service     (0) new service produced and delivered (being a service implies that an agent actively receives the service)
 #   transfer-all-rights (-+) give full (in the human realm) rights and responsibilities to another agent, without transferring physical custody
 #   transfer-custody    (-+) give physical custody and control of a resource, without full accounting or ownership rights
-#   transfer-complete   (-+) give full rights and responsibilities plus physical custody
+#   transfer            (-+) give full rights and responsibilities plus physical custody
 #   move                (-+) change location and/or identity of a resource with no change of agent
 #   raise               (+) adjusts a quantity up based on a beginning balance or inventory count
 #   lower               (-) adjusts a quantity down based on a beginning balance or inventory count

--- a/lib/schemas/mutation.gql
+++ b/lib/schemas/mutation.gql
@@ -201,7 +201,6 @@ type EconomicEventResponse {
 #   unitOfEffort: ID # Unit
 #   state: ID # Action
 #   stage: ID # ProcessSpecification
-#   primaryAccountable: ID # Agent
 # }
 
 """
@@ -215,7 +214,6 @@ input EconomicResourceCreateParams { # implements EconomicResourceParams
   image: URI # URI
   containedIn: ID # EconomicResource
   currentLocation: ID # SpatialThing
-  primaryAccountable: ID # Agent
   note: String
 }
 

--- a/lib/schemas/mutation.gql
+++ b/lib/schemas/mutation.gql
@@ -201,6 +201,7 @@ type EconomicEventResponse {
 #   unitOfEffort: ID # Unit
 #   state: ID # Action
 #   stage: ID # ProcessSpecification
+#   primaryAccountable: ID # Agent
 # }
 
 """
@@ -214,6 +215,7 @@ input EconomicResourceCreateParams { # implements EconomicResourceParams
   image: URI # URI
   containedIn: ID # EconomicResource
   currentLocation: ID # SpatialThing
+  primaryAccountable: ID # Agent
   note: String
 }
 

--- a/lib/schemas/observation.gql
+++ b/lib/schemas/observation.gql
@@ -142,6 +142,9 @@ type EconomicResource {
   "The current place an economic resource is located. Could be at any level of granularity, from a town to an address to a warehouse location. Usually mappable."
   currentLocation: SpatialThing
 
+  "The agent currently with primary rights and responsibilites for the economic resource. It is the agent that is associated with the accountingQuantity of the economic resource."
+  primaryAccountable: Agent
+
   ##############################################################################
   # inverse relationships and queries
 

--- a/mock-server/index.js
+++ b/mock-server/index.js
@@ -2,7 +2,6 @@
  * GraphQL / iQL server
  *
  * @package: HoloREA
- * @author:  pospi <pospi@spadgos.com>
  * @since:   2019-03-18
  */
 


### PR DESCRIPTION
Intermediate VF release v.4.1

* added primaryAccountable to EconomicResource (the agent who "owns" the resource - or is responsible for reporting on accounting reporting)
* changed name of action `transfer-complete` to just `transfer` (dev request)

@pospi I'm not sure I covered the first one correctly in mutations, I added to EconomicResourceCreateParams but not to EconomicResourceUpdateParams.  Trying to follow the pattern I see, but don't know how these are exactly used.  Please correct as needed, thanks.