### PR TITLE
added classifiedAs to Organization

### DIFF
--- a/lib/schemas/agent.gql
+++ b/lib/schemas/agent.gql
@@ -80,6 +80,9 @@ type Organization implements Agent {
   "The uri to an image relevant to the agent, such as a logo, avatar, photo, etc."
   image: URI
 
+  "References one or more concepts in a common taxonomy or other classification scheme for purposes of categorization or grouping."
+  classifiedAs: [URI!]
+
   "A textual description or comment."
   note: String
 


### PR DESCRIPTION
From a discussion with @mayel re CommonsPub requirement for different types of organizations, such as Cooperative, Open Value Network, etc.  (Also will apply to the non-agent groups, not part of VF.)  Will refer to a taxonomy item generally.

Note: This is the first property we have applied to not both Person and Organization.  Not sure the best way to add it to the mutations, so didn't do that.  If this is agreed in general, feel free to do that, or tell me how best to do it.