### PR TITLE
added default unit of resource

### DIFF
--- a/lib/schemas/knowledge.gql
+++ b/lib/schemas/knowledge.gql
@@ -57,7 +57,10 @@ type ResourceSpecification {
   "A textual description or comment."
   note: String
 
-  "[UNSTABLE] The default unit used for quantifying this resource type."
+  "The default unit used for the resource itself."
+  defaultUnitOfResource: Unit
+
+  "The default unit used for use or work."
   defaultUnitOfEffort: Unit
 }
 
@@ -89,7 +92,10 @@ input ResourceSpecificationCreateParams {
   "A textual description or comment."
   note: String
 
-  "(`Unit`) [UNSTABLE] The default unit used for quantifying this resource type."
+  "(`Unit`) The default unit used for the resource itself."
+  defaultUnitOfResource: ID
+
+  "(`Unit`) The default unit used for use or work."
   defaultUnitOfEffort: ID
 }
 
@@ -108,7 +114,10 @@ input ResourceSpecificationUpdateParams {
   "A textual description or comment."
   note: String
 
-  "(`Unit`) [UNSTABLE] The default unit used for quantifying this resource type."
+  "(`Unit`) The default unit used for the resource itself."
+  defaultUnitOfResource: ID
+
+  "(`Unit`) The default unit used for use or work."
   defaultUnitOfEffort: ID
 }
 


### PR DESCRIPTION
@bhaugen caught this - we need both default unit of effort and default unit of the resource itself in ResourceSpecification, for the same reasons - to give guidance on the unit for economic resources/events affecting those resources.

Also cleaned up the definitions, and I don't think they are more unstable than anything else marked unstable in VF....